### PR TITLE
Fixed: There's no way to subclass the Implementation

### DIFF
--- a/MSPeekCollectionViewDelegateImplementation/Classes/MSPeekCollectionViewDelegateImplementation.swift
+++ b/MSPeekCollectionViewDelegateImplementation/Classes/MSPeekCollectionViewDelegateImplementation.swift
@@ -31,7 +31,7 @@ extension UICollectionView {
     }
 }
 
-public class MSPeekCollectionViewDelegateImplementation: NSObject, UICollectionViewDelegateFlowLayout {
+open class MSPeekCollectionViewDelegateImplementation: NSObject, UICollectionViewDelegateFlowLayout {
     
     private let cellPeekWidth: CGFloat
     private let cellSpacing: CGFloat
@@ -58,7 +58,7 @@ public class MSPeekCollectionViewDelegateImplementation: NSObject, UICollectionV
         self.scrollThreshold = scrollThreshold
     }
     
-    public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+    open func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
         let target = targetContentOffset.pointee
         //Current scroll distance is the distance between where the user tapped and the destination for the scrolling (If the velocity is high, this might be of big magnitude)
         let currentScrollDistance = target.x - currentScrollOffset.x
@@ -72,24 +72,24 @@ public class MSPeekCollectionViewDelegateImplementation: NSObject, UICollectionV
         targetContentOffset.pointee = CGPoint(x: adjacentItemOffsetX, y: target.y)
     }
     
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: itemWidth(collectionView), height: collectionView.frame.size.height)
     }
     
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+    open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         let leftAndRightInsets = cellSpacing + cellPeekWidth
         return UIEdgeInsets(top: 0, left: leftAndRightInsets, bottom: 0, right: leftAndRightInsets)
     }
     
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+    open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
         return 0
     }
     
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return cellSpacing
     }
     
-    public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+    open func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         currentScrollOffset = scrollView.contentOffset
     }
 }

--- a/README.md
+++ b/README.md
@@ -141,6 +141,23 @@ extension ViewController: UICollectionViewDataSource {
 }
 ```
 
+## Customization
+### Subclassing
+You can subclass the delegate implementation to integrate other features to it, or listen to certain events:
+```swift
+class SelectablePeekCollectionViewDelegateImplementation: MSPeekCollectionViewDelegateImplementation {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print("Item Selected")
+    }
+    
+    override func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        super.scrollViewWillBeginDragging(scrollView)
+        // Add other code to support other features
+    }
+}
+```
+Note: Make sure you call super on overriden functions (Unless you know what you're doing)
+
 ## Author
 
 Maher Santina, maher.santina90@gmail.com


### PR DESCRIPTION
- Added support for subclassing the implementation
- Added subclassing to readme

closes #8 