### PR TITLE
Added support to scroll multiple cells at once

### DIFF
--- a/Example/MSPeekCollectionViewDelegateImplementation/ViewController.swift
+++ b/Example/MSPeekCollectionViewDelegateImplementation/ViewController.swift
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        delegate = MSPeekCollectionViewDelegateImplementation()
+        delegate = MSPeekCollectionViewDelegateImplementation(maximumItemsToScroll: 3)
         collectionView.configureForPeekingDelegate()
         collectionView.delegate = delegate
         collectionView.dataSource = self

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -107,11 +107,19 @@ class Tests: XCTestCase {
         XCTAssertEqual(simulatedTargetContentOffset.pointee.x, 0)
     }
     
-    func test_ScrollDistanceIsLarge_ShouldScroll1ItemByDefault() {
+    func test_ScrollDistanceIsLarge_MaxIsDefault_ShouldScroll1ItemByDefault() {
         collectionView.frame = CGRect(x: 0, y: 0, width: 320, height: 200)
         sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 20, cellPeekWidth: 20, scrollThreshold: 50)
         let simulatedTargetContentOffset = simulateVerticalScroll(distance: 500)
         XCTAssertEqual(simulatedTargetContentOffset.pointee.x, 260)
+    }
+    
+    //The number of cells that will be scrolled depends on the distance scrolled and the max scroll items specified by the implementation
+    func test_ScrollDistanceIsLarge_MaxIsSet_ShouldScrollProperly() {
+        collectionView.frame = CGRect(x: 0, y: 0, width: 320, height: 200)
+        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 20, cellPeekWidth: 20, scrollThreshold: 50, maximumItemsToScroll: 2)
+        let simulatedTargetContentOffset = simulateVerticalScroll(distance: 640)
+        XCTAssertEqual(simulatedTargetContentOffset.pointee.x, 520)
     }
     
 }

--- a/README.md
+++ b/README.md
@@ -65,15 +65,19 @@ Or you can use one of the initializers that takes arguments:
 delegate = MSPeekCollectionViewDelegateImplementation(cellSpacing: 10)
 ```
 ```swift
-delegate = MSPeekCollectionViewDelegateImplementation(cellSpacing: 10, cellPeekWidth: 20)
+delegate = MSPeekCollectionViewDelegateImplementation(cellPeekWidth: 20)
 ```
 ```swift
-delegate = MSPeekCollectionViewDelegateImplementation(cellSpacing: 10, cellPeekWidth: 20, scrollThreshold: 150)
+//scrollThreshold is the minimum amount of scroll distance required to move to the adjacent item.
+delegate = MSPeekCollectionViewDelegateImplementation(scrollThreshold: 150)
+```
+```swift
+//maximumItemsToScroll is the maximum number of items that can be scrolled if the scroll distance is large
+delegate = MSPeekCollectionViewDelegateImplementation(maximumItemsToScroll: 3)
 ```
 
 ![peek explanation](https://user-images.githubusercontent.com/24646608/41348656-b0ad14fc-6f50-11e8-8723-2996b016e9c9.jpg)
 
-The scroll threshold is the minimum amount of scroll distance required to move to the adjacent item.
 
 9. In `viewDidLoad()`, set the collection view's delegate:
 ```swift


### PR DESCRIPTION
This is done by initializing the implementation with `maimumItemsToScroll` parameter set to the desired value.
Closes #7 