### PR TITLE
Fixed large cell spacing or peek width causing problems in scroll

### DIFF
--- a/Example/Tests/HorizontalScrollDirectionTests.swift
+++ b/Example/Tests/HorizontalScrollDirectionTests.swift
@@ -93,20 +93,40 @@ class HorizontalScrollDirectionTests: XCTestCase {
     }
     
     func test_ScrollViewWillEndDragging_ScrollGreaterThanThreshold_DirectionRight_ShouldScrollToNextItem() {
+        
         collectionView.frame = CGRect(x: 0, y: 0, width: 320, height: 200)
         sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 20, cellPeekWidth: 20, scrollThreshold: 50)
         collectionView.contentOffset = CGPoint(x: 0, y: 0)
         sut.scrollViewWillBeginDragging(collectionView)
         let simulatedTargetContentOffset = simulateHorizontalScroll(distance: 50)
         XCTAssertEqual(simulatedTargetContentOffset.pointee.x, 260)
+        
+        collectionView.frame = CGRect(x: 0, y: 0, width: 320, height: 200)
+        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 0, cellPeekWidth: 20, scrollThreshold: 50)
+        collectionView.contentOffset = CGPoint(x: 0, y: 0)
+        sut.scrollViewWillBeginDragging(collectionView)
+        let simulatedTargetContentOffset2 = simulateHorizontalScroll(distance: 50)
+        XCTAssertEqual(simulatedTargetContentOffset2.pointee.x, 280)
     }
     
     func test_ScrollViewWillEndDragging_ScrollGreaterThanThreshold_DirectionLeft_ShouldScrollToPreviousItem() {
-        collectionView.frame = CGRect(x: 0, y: 0, width: 320, height: 200)
-        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 20, cellPeekWidth: 20, scrollThreshold: 50)
-        collectionView.contentOffset = CGPoint(x: 260, y: 0)
-        let simulatedTargetContentOffset = simulateHorizontalScroll(distance: -51)
-        XCTAssertEqual(simulatedTargetContentOffset.pointee.x, 0)
+//        collectionView.frame = CGRect(x: 0, y: 0, width: 320, height: 200)
+//        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 20, cellPeekWidth: 20, scrollThreshold: 50)
+//        collectionView.contentOffset = CGPoint(x: 260, y: 0)
+//        let simulatedTargetContentOffset = simulateHorizontalScroll(distance: -51)
+//        XCTAssertEqual(simulatedTargetContentOffset.pointee.x, 0)
+//
+//        collectionView.frame = CGRect(x: 0, y: 0, width: 320, height: 200)
+//        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 70, cellPeekWidth: 20, scrollThreshold: 50)
+//        collectionView.contentOffset = CGPoint(x: 480, y: 0)
+//        let simulatedTargetContentOffset2 = simulateHorizontalScroll(distance: -51)
+//        XCTAssertEqual(simulatedTargetContentOffset2.pointee.x, 320)
+        
+        collectionView.frame = CGRect(x: 0, y: 0, width: 400, height: 200)
+        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 0, cellPeekWidth: 0, scrollThreshold: 50)
+        collectionView.contentOffset = CGPoint(x: 600, y: 0)
+        let simulatedTargetContentOffset3 = simulateHorizontalScroll(distance: -51)
+        XCTAssertEqual(simulatedTargetContentOffset3.pointee.x, 400)
     }
     
     func test_ScrollDistanceIsLarge_MaxIsDefault_ShouldScroll1ItemByDefault() {
@@ -131,6 +151,21 @@ class HorizontalScrollDirectionTests: XCTestCase {
         XCTAssertEqual(offset, 0)
         let offset2 = sut.scrollView(collectionView, contentOffsetForItemAtIndex: 1)
         XCTAssertEqual(offset2, 260)
+    }
+    
+    func test_indexForItemAtContentOffset_ShouldReturnCorrectIndex() {
+        collectionView.frame = CGRect(x: 0, y: 0, width: 320, height: 200)
+        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 0, cellPeekWidth: 0, scrollThreshold: 50, maximumItemsToScroll: 2)
+        let offset = sut.scrollView(collectionView, indexForItemAtContentOffset: CGPoint(x: 640, y: 0))
+        XCTAssertEqual(offset, 2)
+        
+        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 20, cellPeekWidth: 20, scrollThreshold: 50, maximumItemsToScroll: 1)
+        let offset2 = sut.scrollView(collectionView, indexForItemAtContentOffset: CGPoint(x: 520, y: 0))
+        XCTAssertEqual(offset2, 2)
+        
+        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 50, cellPeekWidth: 20, scrollThreshold: 50, maximumItemsToScroll: 1)
+        let offset3 = sut.scrollView(collectionView, indexForItemAtContentOffset: CGPoint(x: 600, y: 0))
+        XCTAssertEqual(offset3, 3)
     }
     
 }

--- a/Example/Tests/VerticalScrollDirectionTests.swift
+++ b/Example/Tests/VerticalScrollDirectionTests.swift
@@ -135,6 +135,21 @@ class VerticalScrollDirectionTests: XCTestCase {
         XCTAssertEqual(offset2, 140)
     }
     
+    func test_indexForItemAtContentOffset_ShouldReturnCorrectIndex() {
+        collectionView.frame = CGRect(x: 0, y: 0, width: 320, height: 200)
+        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 0, cellPeekWidth: 0, scrollThreshold: 50, maximumItemsToScroll: 2, scrollDirection: .vertical)
+        let offset = sut.scrollView(collectionView, indexForItemAtContentOffset: CGPoint(x: 0, y: 400))
+        XCTAssertEqual(offset, 2)
+        
+        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 20, cellPeekWidth: 20, scrollThreshold: 50, maximumItemsToScroll: 1, scrollDirection: .vertical)
+        let offset2 = sut.scrollView(collectionView, indexForItemAtContentOffset: CGPoint(x: 0, y: 280))
+        XCTAssertEqual(offset2, 2)
+        
+        sut = MSPeekCollectionViewDelegateImplementation(cellSpacing: 50, cellPeekWidth: 20, scrollThreshold: 50, maximumItemsToScroll: 1, scrollDirection: .vertical)
+        let offset3 = sut.scrollView(collectionView, indexForItemAtContentOffset: CGPoint(x: 0, y: 220))
+        XCTAssertEqual(offset3, 2)
+    }
+    
 }
 
 extension VerticalScrollDirectionTests: UICollectionViewDataSource {

--- a/MSPeekCollectionViewDelegateImplementation/Classes/MSPeekCollectionViewDelegateImplementation.swift
+++ b/MSPeekCollectionViewDelegateImplementation/Classes/MSPeekCollectionViewDelegateImplementation.swift
@@ -57,15 +57,6 @@ open class MSPeekCollectionViewDelegateImplementation: NSObject, UICollectionVie
         return max(0, finalWidth)
     }
     
-    private lazy var currentItemIndex: (UIView) -> Int = {
-        view in
-        guard self.itemWidth(view) > 0 else {
-            return 0
-        }
-        let offset = self.getValueFromPoint(self.currentScrollOffset)
-        return Int(round(offset/self.itemWidth(view)))
-    }
-    
     private func getViewWidth(_ view: UIView) -> CGFloat {
         switch scrollDirection {
         case .horizontal:
@@ -81,6 +72,15 @@ open class MSPeekCollectionViewDelegateImplementation: NSObject, UICollectionVie
             return point.x
         case .vertical:
             return point.y
+        }
+    }
+    
+    private func getValueFromSize(_ size: CGSize) -> CGFloat {
+        switch scrollDirection {
+        case .horizontal:
+            return size.width
+        case .vertical:
+            return size.height
         }
     }
     
@@ -131,10 +131,20 @@ open class MSPeekCollectionViewDelegateImplementation: NSObject, UICollectionVie
         let currentScrollDistance = getValueFromPoint(target) - getValueFromPoint(currentScrollOffset)
         let coefficient = calculateCoefficient(scrollDistance: currentScrollDistance, scrollWidth: itemWidth(scrollView))
         
-        let adjacentItemIndex = currentItemIndex(scrollView) + coefficient
-        let adjacentItemOffsetX = self.scrollView(scrollView, contentOffsetForItemAtIndex: adjacentItemIndex)
+        let adjacentItemNumber = self.scrollView(scrollView, indexForItemAtContentOffset: currentScrollOffset) + coefficient
+        let adjacentItemOffsetX = self.scrollView(scrollView, contentOffsetForItemAtIndex: adjacentItemNumber)
         
         targetContentOffset.pointee = getPointFromValue(adjacentItemOffsetX, defaultPoint: target)
+    }
+    
+    open func scrollView(_ scrollView: UIScrollView, indexForItemAtContentOffset contentOffset: CGPoint) -> Int {
+        let width = itemWidth(scrollView) + cellSpacing
+        guard width > 0 else {
+            return 0
+        }
+        let offset = self.getValueFromPoint(contentOffset)
+        let index = Int(round(offset/width))
+        return index
     }
     
     open func scrollView(_ scrollView: UIScrollView, contentOffsetForItemAtIndex index: Int) -> CGFloat{


### PR DESCRIPTION
Index of cell was not calculated properly if the cell peek width or cell spacing is large.

Also, I've added a convenience function to get the index of an item based on the content offset:
```swift
open func scrollView(_ scrollView: UIScrollView, indexForItemAtContentOffset contentOffset: CGPoint)
```

Closes #20, #21 