### PR TITLE
`targetContentOffset` bugfix

### DIFF
--- a/MSPeekCollectionViewDelegateImplementation/Classes/MSPeekCollectionViewDelegateImplementation.swift
+++ b/MSPeekCollectionViewDelegateImplementation/Classes/MSPeekCollectionViewDelegateImplementation.swift
@@ -30,6 +30,7 @@ extension UICollectionView {
         self.decelerationRate = UIScrollViewDecelerationRateFast
         self.showsHorizontalScrollIndicator = false
         self.showsVerticalScrollIndicator = false
+        self.isPagingEnabled = false
         //Keeping this to support older versions
         let layout = collectionViewLayout as! UICollectionViewFlowLayout
         layout.scrollDirection = scrollDirection


### PR DESCRIPTION
This fixes `targetContentOffset` bug in `scrollViewWillEndDragging` where the offset is a multiplier of the UICollectionView bounds' width if `UICollectionView` paging is enabled.